### PR TITLE
refactor uci module

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,13 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: rustfmt
+        run: rustfmt --check src/*.rs
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,5 @@
-use std::sync::mpsc;
-use std::thread;
-
 mod uci;
 
 fn main() {
-    let (sender, receiver) = mpsc::channel();
-
-    let producer_handle = thread::spawn(move || uci::producer(sender));
-    let consumer_handle = thread::spawn(move || uci::consumer(receiver));
-
-    producer_handle.join().unwrap();
-    consumer_handle.join().unwrap();
+    uci::start_uci_engine();
 }

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -1,6 +1,19 @@
 use regex::RegexSet;
 use std::io;
 use std::sync::mpsc;
+use std::thread;
+
+// Begin accepting UCI commands from stdin. This is the entry point for running
+// Challenger. All game actions and modifications begin from stdin.
+pub fn start_uci_engine() {
+    let (sender, receiver) = mpsc::channel();
+
+    let producer_handle = thread::spawn(move || producer(sender));
+    let consumer_handle = thread::spawn(move || consumer(receiver));
+
+    producer_handle.join().unwrap();
+    consumer_handle.join().unwrap();
+}
 
 // Commands represent valid UCI commands entered by a user. Only valid commands
 // should ever be sent to the Challenger engine to execute, so user input MUST

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -18,7 +18,7 @@ pub fn start_uci_engine() {
 // Commands represent valid UCI commands entered by a user. Only valid commands
 // should ever be sent to the Challenger engine to execute, so user input MUST
 // be validated before the '.execute()' method is called by the engine.
-pub struct Command {
+struct Command {
     input_string: String,
 }
 
@@ -66,7 +66,7 @@ fn validate_input_string(input: &str) -> Result<String, &str> {
 
 // "Produces" Commands by parsing stdin input and sending the resulting
 // Command struct to the consuming mpsc::Receiver
-pub fn producer(tx: mpsc::Sender<Command>) {
+fn producer(tx: mpsc::Sender<Command>) {
     loop {
         let mut buffer = String::new();
         io::stdin().read_line(&mut buffer).unwrap();
@@ -90,7 +90,7 @@ pub fn producer(tx: mpsc::Sender<Command>) {
 
 // "Consumes" Commands by reading from the mpsc::Receiver and executing
 // the received Command.
-pub fn consumer(rx: mpsc::Receiver<Command>) {
+fn consumer(rx: mpsc::Receiver<Command>) {
     for command in rx {
         command.execute();
     }

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -19,15 +19,13 @@ pub fn start_uci_engine() {
 // should ever be sent to the Challenger engine to execute, so user input MUST
 // be validated before the '.execute()' method is called by the engine.
 struct Command {
-    input_string: String,
+    uci_string: String,
 }
 
 impl Command {
     pub fn from(input: &str) -> Result<Command, &str> {
-        let valid_input = validate_input_string(input)?;
-        Ok(Command {
-            input_string: valid_input,
-        })
+        let uci_string = validate_input_string(input)?;
+        Ok(Command { uci_string })
     }
 
     pub fn execute(&self) {
@@ -38,7 +36,7 @@ impl Command {
     }
 
     pub fn tokens(&self) -> Vec<&str> {
-        return self.input_string.split_whitespace().collect();
+        return self.uci_string.split_whitespace().collect();
     }
 }
 


### PR DESCRIPTION
* Move lingering logic for starting the UCI command process in main.rs to uci.rs
* Rename internal variables
* Adjust module privacy specifiers
* Add lint job in test workflow