### PR TITLE
Switch to static regex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,8 +13,15 @@ dependencies = [
 name = "challenger-rs"
 version = "0.1.0"
 dependencies = [
+ "lazy_static",
  "regex",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "memchr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2018"
 
 [dependencies]
 regex = "1.5"
+lazy_static = "1.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,9 @@ mod gamestate;
 mod position;
 mod uci;
 
+#[macro_use]
+extern crate lazy_static;
+
 fn main() {
     uci::start_uci_engine();
 }

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -51,22 +51,23 @@ impl Command {
     }
 }
 
+lazy_static! {
+    static ref UCI_REGEX_SET: RegexSet = RegexSet::new(&[
+        r"^(?:uci|isready|ucinewgame|stop|ponderhit)$",
+        r"^debug (?:on|off)$",
+        r"^position (?:startpos|(?:[rnbqkp12345678RNBQKP]{1,8}/){7}[rnbqkp12345678RNBQKP]{1,8} (w|b) (?:-|[KQkq]{1,4}) (?:-|[a-h][1-8]) (?:\d)+ (?:\d)+)(?: moves(?: [a-h][1-8][a-h][1-8][rnbqRNBQ]?)+)?$",
+        r"^go(?: ponder| infinite| (?:wtime|btime|winc|binc|movestogo|depth|nodes|mate|movetime) [\d]+| searchmoves(?: [a-h][1-8][a-h][1-8][rnbqRNBQ]?)+)*$",
+        r"^setoption [[:word:]]+(?: value [[:word:]]+)?$"
+    ]).unwrap();
+}
+
 // Validate that the input is a well-formed UCI command string. Return the
 // command tokens in a vector, or Err() if invalid.
 fn validate_input_string(input: &str) -> Result<String, &str> {
     let input = input.trim();
 
     // Match the input against known Universal Chess Interface (UCI) commands
-    let uci_regex_set =
-            RegexSet::new(&[
-                r"^(?:uci|isready|ucinewgame|stop|ponderhit)$",
-                r"^debug (?:on|off)$",
-                r"^position (?:startpos|(?:[rnbqkp12345678RNBQKP]{1,8}/){7}[rnbqkp12345678RNBQKP]{1,8} (w|b) (?:-|[KQkq]{1,4}) (?:-|[a-h][1-8]) (?:\d)+ (?:\d)+)(?: moves(?: [a-h][1-8][a-h][1-8][rnbqRNBQ]?)+)?$",
-                r"^go(?: ponder| infinite| (?:wtime|btime|winc|binc|movestogo|depth|nodes|mate|movetime) [\d]+| searchmoves(?: [a-h][1-8][a-h][1-8][rnbqRNBQ]?)+)*$",
-                r"^setoption [[:word:]]+(?: value [[:word:]]+)?$"
-            ]).unwrap();
-
-    if uci_regex_set.is_match(&input) {
+    if UCI_REGEX_SET.is_match(&input) {
         Ok(String::from(input))
     } else {
         Err("Command failed UCI regex validation")


### PR DESCRIPTION
As described in
https://docs.rs/regex/1.5.4/regex/#example-avoid-compiling-the-same-regex-in-a-loop,
compiling the same regex in a loop is a computationally expensive antipattern.
Switching to the recommended (by the regex crate documentation) use of
lazy_static will reuse the compiled regex on subsequent invocations.