### PR TITLE
Improve sq_to_bitboard performance

### DIFF
--- a/src/position.rs
+++ b/src/position.rs
@@ -173,9 +173,9 @@ impl Position {
 }
 
 fn sq_to_bitboard(file: char, rank: char) -> u64 {
-    let file_squares = file.to_digit(18).unwrap() - 9;
-    let rank_squares = (rank.to_digit(10).unwrap() - 1) * 8;
-    1u64 << (rank_squares + file_squares - 1)
+    let file_squares = file as u32 - 'a' as u32;
+    let rank_squares = (rank as u32 - '1' as u32) * 8;
+    1u64 << (rank_squares + file_squares)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Using to_digit() causes unnecessary function call and logic overhead
when the bounds of both file and rank are known ahead of time. Casting
to u32 and subracting is how the standard library implements this
functionality but with extra logic around the radix and returning an
Option<T> instead of the value we really wanted.